### PR TITLE
[IBCDPE-505] Adapt `nf-cwl-wrap` for Nextflow Tower

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .nextflow.log.*
 work/
 .nextflow/
+nextflow

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,5 @@
 FROM python:3.11
 
-#install apt-get dependencies
-RUN apt-get update -y
-RUN apt-get upgrade -y
-RUN apt-get install -y git gcc python3 libxml2-dev libxslt-dev libc-dev
-RUN apt install -y nodejs
-RUN apt-get install -y graphviz libxml2
-RUN apt-get install -y bash
-
 #Add the official Docker (apt-get) repository
 RUN mkdir -p /etc/apt/keyrings
 RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg \
@@ -17,9 +9,19 @@ RUN echo \
     focal stable" \
     | tee /etc/apt/sources.list.d/docker.list > /dev/null
 
-# Install Docker - not sure why it won't work unless you update apt-get again
-RUN apt-get update -y 
-RUN apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+#install apt-get dependencies
+RUN apt-get update -y && apt-get upgrade -y && apt-get install -y \
+    git \
+    gcc \
+    python3 \
+    libxml2-dev \
+    libxslt-dev \
+    libc-dev \
+    nodejs \
+    graphviz \
+    libxml2 \
+    bash \
+    docker-ce 
 
 # Clone cwltool repo - specific commit ID to control changes
 RUN git clone https://github.com/common-workflow-language/cwltool.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,9 +7,10 @@ ENTRYPOINT [""]
 VOLUME /var/run/docker.sock:/var/run/docker.sock
 VOLUME /tmp:/tmp
 
-#install bash
+#install bash and curl
 RUN apk update
 RUN apk upgrade
 RUN apk add bash
 
+#keep contianer running and listening for commands
 CMD ["tail", "-f", "/dev/null"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,14 +27,15 @@ RUN apt-get update -y && apt-get upgrade -y && apt-get install -y \
 RUN git clone https://github.com/common-workflow-language/cwltool.git && cd cwltool && git checkout 40c338c
 WORKDIR /cwltool
 
-# Install cwltool
-# The following comes directly from the original docker image
+# Install cwltool 
+ENV BLACK_VERSION="22.0"
+# The following comes directly from the original docker image (except for ENV version pinning and install location)
 RUN CWLTOOL_USE_MYPYC=1 MYPYPATH=mypy-stubs pip wheel --no-binary schema-salad \
     --wheel-dir=/wheels .[deps]  # --verbose
 RUN rm /wheels/schema_salad*
-RUN pip install "black~=22.0"
+RUN pip install "black~=$BLACK_VERSION"
 RUN SCHEMA_SALAD_USE_MYPYC=1 MYPYPATH=mypy-stubs pip wheel --no-binary schema-salad \
-    $(grep schema.salad requirements.txt) "black~=22.0" --wheel-dir=/wheels  # --verbose
+    $(grep schema.salad requirements.txt) "black~=$BLACK_VERSION" --wheel-dir=/wheels  # --verbose
 RUN pip install --force-reinstall --no-index --no-warn-script-location \
     --root=/ /wheels/*.whl
 WORKDIR /

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,3 +6,5 @@ ENTRYPOINT [""]
 # Mount directories
 VOLUME /var/run/docker.sock:/var/run/docker.sock
 VOLUME /tmp:/tmp
+
+CMD ["tail", "-f", "/dev/null"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,6 @@ FROM python:3.11
 #install apt-get dependencies
 RUN apt-get update -y
 RUN apt-get upgrade -y
-
 RUN apt-get install -y git gcc python3 libxml2-dev libxslt-dev libc-dev
 RUN apt install -y nodejs
 RUN apt-get install -y graphviz libxml2
@@ -17,14 +16,18 @@ RUN echo \
     "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
     focal stable" \
     | tee /etc/apt/sources.list.d/docker.list > /dev/null
+
 # Install Docker - not sure why it won't work unless you update apt-get again
 RUN apt-get update -y 
 RUN apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
 
-# Install cwltool - specific commit ID to control changes
+# Clone cwltool repo - specific commit ID to control changes
 RUN git clone https://github.com/common-workflow-language/cwltool.git
 WORKDIR /cwltool
 RUN git checkout 40c338c
+
+# Install cwltool
+# The following comes directly form the original docker image
 RUN CWLTOOL_USE_MYPYC=1 MYPYPATH=mypy-stubs pip wheel --no-binary schema-salad \
     --wheel-dir=/wheels .[deps]  # --verbose
 RUN rm /wheels/schema_salad*

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,14 +3,10 @@ FROM quay.io/commonwl/cwltool:3.1.20230213100550
 # Set entrypoint
 ENTRYPOINT [""]
 
-# Mount directories
-# VOLUME /var/run/docker.sock:/var/run/docker.sock
-# VOLUME /tmp:/tmp
-
 #install bash and curl
-RUN apk update
-RUN apk upgrade
-RUN apk add bash
+#RUN apk update
+#RUN apk upgrade
+#RUN apk add bash
 
 #keep container running and listening for commands
-CMD ["tail", "-f", "/dev/null"]
+#CMD ["tail", "-f", "/dev/null"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,13 @@
 FROM quay.io/commonwl/cwltool:3.1.20230213100550
 
-# Set entrypoint
-ENTRYPOINT [""]
-
 #install bash
 RUN apk update
 RUN apk upgrade
 RUN apk add bash
+
+# Set entrypoint
+ENTRYPOINT [""]
+
 
 #keep container running and listening for commands
 #CMD ["tail", "-f", "/dev/null"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,8 @@ FROM quay.io/commonwl/cwltool:3.1.20230213100550
 ENTRYPOINT [""]
 
 # Mount directories
-VOLUME /var/run/docker.sock:/var/run/docker.sock
-VOLUME /tmp:/tmp
+# VOLUME /var/run/docker.sock:/var/run/docker.sock
+# VOLUME /tmp:/tmp
 
 #install bash and curl
 RUN apk update

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM quay.io/commonwl/cwltool:3.1.20230213100550
+
+# Set entrypoint
+ENTRYPOINT [""]
+
+# Mount directories
+VOLUME /var/run/docker.sock:/var/run/docker.sock
+VOLUME /tmp:/tmp

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,4 +7,9 @@ ENTRYPOINT [""]
 VOLUME /var/run/docker.sock:/var/run/docker.sock
 VOLUME /tmp:/tmp
 
+#install bash
+RUN apk update
+RUN apk upgrade
+RUN apk add bash
+
 CMD ["tail", "-f", "/dev/null"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,36 @@
-FROM quay.io/commonwl/cwltool:3.1.20230213100550
+FROM python:3.11
 
-# Set entrypoint
-ENTRYPOINT [""]
+#install apt-get dependencies
+RUN apt-get update -y
+RUN apt-get upgrade -y
 
-#install bash
-RUN apk update
-RUN apk upgrade
-RUN apk add bash
+RUN apt-get install -y git gcc python3 libxml2-dev libxslt-dev libc-dev
+RUN apt install -y nodejs
+RUN apt-get install -y graphviz libxml2
+RUN apt-get install -y bash
+
+#Add the official Docker (apt-get) repository
+RUN mkdir -p /etc/apt/keyrings
+RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg \
+    | gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+RUN echo \
+    "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
+    focal stable" \
+    | tee /etc/apt/sources.list.d/docker.list > /dev/null
+# Install Docker - not sure why it won't work unless you update apt-get again
+RUN apt-get update -y 
+RUN apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+
+# Install cwltool - specific commit ID to control changes
+RUN git clone https://github.com/common-workflow-language/cwltool.git
+WORKDIR /cwltool
+RUN git checkout 40c338c
+RUN CWLTOOL_USE_MYPYC=1 MYPYPATH=mypy-stubs pip wheel --no-binary schema-salad \
+    --wheel-dir=/wheels .[deps]  # --verbose
+RUN rm /wheels/schema_salad*
+RUN pip install "black~=22.0"
+RUN SCHEMA_SALAD_USE_MYPYC=1 MYPYPATH=mypy-stubs pip wheel --no-binary schema-salad \
+    $(grep schema.salad requirements.txt) "black~=22.0" --wheel-dir=/wheels  # --verbose
+RUN pip install --force-reinstall --no-index --no-warn-script-location \
+    --root=/ /wheels/*.whl
+WORKDIR /

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,12 +24,11 @@ RUN apt-get update -y && apt-get upgrade -y && apt-get install -y \
     docker-ce 
 
 # Clone cwltool repo - specific commit ID to control changes
-RUN git clone https://github.com/common-workflow-language/cwltool.git
+RUN git clone https://github.com/common-workflow-language/cwltool.git && cd cwltool && git checkout 40c338c
 WORKDIR /cwltool
-RUN git checkout 40c338c
 
 # Install cwltool
-# The following comes directly form the original docker image
+# The following comes directly from the original docker image
 RUN CWLTOOL_USE_MYPYC=1 MYPYPATH=mypy-stubs pip wheel --no-binary schema-salad \
     --wheel-dir=/wheels .[deps]  # --verbose
 RUN rm /wheels/schema_salad*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,9 @@
 FROM quay.io/commonwl/cwltool:3.1.20230213100550
 
+# Set entrypoint
+ENTRYPOINT [""]
+
 #install bash
 RUN apk update
 RUN apk upgrade
 RUN apk add bash
-
-# Set entrypoint
-ENTRYPOINT [""]
-
-
-#keep container running and listening for commands
-#CMD ["tail", "-f", "/dev/null"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,10 @@ FROM quay.io/commonwl/cwltool:3.1.20230213100550
 # Set entrypoint
 ENTRYPOINT [""]
 
-#install bash and curl
-#RUN apk update
-#RUN apk upgrade
-#RUN apk add bash
+#install bash
+RUN apk update
+RUN apk upgrade
+RUN apk add bash
 
 #keep container running and listening for commands
 #CMD ["tail", "-f", "/dev/null"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,5 +12,5 @@ RUN apk update
 RUN apk upgrade
 RUN apk add bash
 
-#keep contianer running and listening for commands
+#keep container running and listening for commands
 CMD ["tail", "-f", "/dev/null"]

--- a/main.nf
+++ b/main.nf
@@ -8,7 +8,7 @@ params.input_file = "${projectDir}/example_inputs/epic.json"
 
 //runs cwl workflow using url and params provided
 process EXECUTE_CWL_WORKFLOW {
-    // containerOptions = '--entrypoint "" -v "/var/run/docker.sock:/var/run/docker.sock" -v /tmp:/tmp'
+    containerOptions = '-v "/var/run/docker.sock:/var/run/docker.sock" -v /tmp:/tmp'
     container "bwmac03570/cwl-wrap:1.0"
 
     input:

--- a/main.nf
+++ b/main.nf
@@ -9,7 +9,7 @@ params.input_file = "${projectDir}/example_inputs/epic.json"
 //runs cwl workflow using url and params provided
 process EXECUTE_CWL_WORKFLOW {
     containerOptions = '-v "/var/run/docker.sock:/var/run/docker.sock" -v /tmp:/tmp'
-    container "ubuntu"
+    container "quay.io/commonwl/cwltool:3.1.20230213100550"
 
     input:
     path cwl_file

--- a/main.nf
+++ b/main.nf
@@ -1,7 +1,7 @@
 // Ensure DSL2
 nextflow.enable.dsl = 2
 
-//url for exmaple CWL workflow
+//url for example CWL workflow
 params.cwl_file = "https://raw.githubusercontent.com/CRI-iAtlas/iatlas-workflows/develop/EPIC/workflow/steps/epic/epic.cwl"
 //example params file
 params.input_file = "${projectDir}/example_inputs/epic.json"

--- a/main.nf
+++ b/main.nf
@@ -9,7 +9,7 @@ params.input_file = "${projectDir}/example_inputs/epic.json"
 //runs cwl workflow using url and params provided
 process EXECUTE_CWL_WORKFLOW {
     containerOptions = '-v "/var/run/docker.sock:/var/run/docker.sock" -v /tmp:/tmp'
-    container "bwmac03570/cwl-tool-no-entry:test-no-workdir"
+    container "bwmac03570/cwl-tool-no-entry:test-dup"
 
     input:
     path cwl_file

--- a/main.nf
+++ b/main.nf
@@ -9,7 +9,7 @@ params.input_file = "${projectDir}/example_inputs/epic.json"
 //runs cwl workflow using url and params provided
 process EXECUTE_CWL_WORKFLOW {
     containerOptions = '-v "/var/run/docker.sock:/var/run/docker.sock" -v /tmp:/tmp'
-    container "bwmac03570/cwl-wrap:1.0"
+    container "bwmac03570/cwl-tool-no-entry:test"
 
     input:
     path cwl_file

--- a/main.nf
+++ b/main.nf
@@ -9,7 +9,7 @@ params.input_file = "${projectDir}/example_inputs/epic.json"
 //runs cwl workflow using url and params provided
 process EXECUTE_CWL_WORKFLOW {
     containerOptions = '-v "/var/run/docker.sock:/var/run/docker.sock" -v /tmp:/tmp'
-    container "bwmac03570/cwl-tool-no-entry:git-test"
+    container "ghcr.io/sage-bionetworks-workflows/nf-cwl-wrap:1.0"
 
     input:
     path cwl_file

--- a/main.nf
+++ b/main.nf
@@ -17,7 +17,9 @@ process EXECUTE_CWL_WORKFLOW {
 
     script:
     """
-    echo "Hello World!"
+    #!/bin/sh
+    
+    cwltool ${cwl_file} ${input_file}
     """
 }
 

--- a/main.nf
+++ b/main.nf
@@ -8,6 +8,7 @@ params.input_file = "${projectDir}/example_inputs/epic.json"
 
 //runs cwl workflow using url and params provided
 process EXECUTE_CWL_WORKFLOW {
+    // containerOptions only work when run locally, aws batch volume mounting in nextflow.config for Tower runs
     containerOptions = '-v "/var/run/docker.sock:/var/run/docker.sock" -v /tmp:/tmp'
     container "ghcr.io/sage-bionetworks-workflows/nf-cwl-wrap:1.0"
 

--- a/main.nf
+++ b/main.nf
@@ -8,8 +8,8 @@ params.input_file = "${projectDir}/example_inputs/epic.json"
 
 //runs cwl workflow using url and params provided
 process EXECUTE_CWL_WORKFLOW {
-    containerOptions = '--entrypoint "" -v "/var/run/docker.sock:/var/run/docker.sock" -v /tmp:/tmp'
-    container "quay.io/commonwl/cwltool:3.1.20230213100550"
+    // containerOptions = '--entrypoint "" -v "/var/run/docker.sock:/var/run/docker.sock" -v /tmp:/tmp'
+    container "bwmac03570/cwl-wrap:1.0"
 
     input:
     path cwl_file

--- a/main.nf
+++ b/main.nf
@@ -9,7 +9,7 @@ params.input_file = "${projectDir}/example_inputs/epic.json"
 //runs cwl workflow using url and params provided
 process EXECUTE_CWL_WORKFLOW {
     containerOptions = '-v "/var/run/docker.sock:/var/run/docker.sock" -v /tmp:/tmp'
-    container "bwmac03570/cwl-tool-no-entry:test-no-alpine"
+    container "bwmac03570/cwl-tool-no-entry:git-test"
 
     input:
     path cwl_file

--- a/main.nf
+++ b/main.nf
@@ -9,7 +9,7 @@ params.input_file = "${projectDir}/example_inputs/epic.json"
 //runs cwl workflow using url and params provided
 process EXECUTE_CWL_WORKFLOW {
     containerOptions = '-v "/var/run/docker.sock:/var/run/docker.sock" -v /tmp:/tmp'
-    container "quay.io/commonwl/cwltool:3.1.20230213100550"
+    container "bwmac03570/cwl-wrap:1.0"
 
     input:
     path cwl_file

--- a/main.nf
+++ b/main.nf
@@ -9,7 +9,7 @@ params.input_file = "${projectDir}/example_inputs/epic.json"
 //runs cwl workflow using url and params provided
 process EXECUTE_CWL_WORKFLOW {
     containerOptions = '-v "/var/run/docker.sock:/var/run/docker.sock" -v /tmp:/tmp'
-    container "bwmac03570/cwl-tool-no-entry:test-dup"
+    container "bwmac03570/cwl-tool-no-entry:test-default-workdir"
 
     input:
     path cwl_file

--- a/main.nf
+++ b/main.nf
@@ -9,7 +9,7 @@ params.input_file = "${projectDir}/example_inputs/epic.json"
 //runs cwl workflow using url and params provided
 process EXECUTE_CWL_WORKFLOW {
     containerOptions = '-v "/var/run/docker.sock:/var/run/docker.sock" -v /tmp:/tmp'
-    container "bwmac03570/cwl-wrap:1.0"
+    container "ubuntu"
 
     input:
     path cwl_file
@@ -17,9 +17,7 @@ process EXECUTE_CWL_WORKFLOW {
 
     script:
     """
-    #!/bin/sh
-
-    cwltool ${cwl_file} ${input_file}
+    echo "Hello World!"
     """
 }
 

--- a/main.nf
+++ b/main.nf
@@ -9,7 +9,7 @@ params.input_file = "${projectDir}/example_inputs/epic.json"
 //runs cwl workflow using url and params provided
 process EXECUTE_CWL_WORKFLOW {
     containerOptions = '-v "/var/run/docker.sock:/var/run/docker.sock" -v /tmp:/tmp'
-    container "bwmac03570/cwl-tool-no-entry:test-default-workdir"
+    container "bwmac03570/cwl-tool-no-entry:test-no-alpine"
 
     input:
     path cwl_file

--- a/main.nf
+++ b/main.nf
@@ -9,7 +9,7 @@ params.input_file = "${projectDir}/example_inputs/epic.json"
 //runs cwl workflow using url and params provided
 process EXECUTE_CWL_WORKFLOW {
     containerOptions = '-v "/var/run/docker.sock:/var/run/docker.sock" -v /tmp:/tmp'
-    container "bwmac03570/cwl-tool-no-entry:test"
+    container "bwmac03570/cwl-tool-no-entry:test-no-workdir"
 
     input:
     path cwl_file

--- a/nextflow.config
+++ b/nextflow.config
@@ -1,3 +1,5 @@
 docker {
 	enabled = true
 }
+
+aws.batch.volumes = [ '/var/run/docker.sock:/var/run/docker.sock', '/tmp:/tmp' ]


### PR DESCRIPTION
This PR adapts `nf-cwl-wrap` to work on Nextflow Tower.

The primary barrier to running CWL workflows on Nextflow Tower using this workflow was the `cwltool` [docker container](https://github.com/common-workflow-language/cwltool/blob/main/cwltool.Dockerfile) causing an AWS CLI error when run on Tower. It turns out that this error was because the [base image](https://hub.docker.com/layers/library/python/3.11.0a3-alpine/images/sha256-6233b624f2382a248c544076d8fa4665352e0260187e8a350c773a512370e5d1) that it is built from does not support the AWS CLI. In order to solve this problem, I created our own docker image (`Dockerfile` in this branch) that is built from a Ubuntu-based python docker image instead. The new docker image is now hosted publicly [here](https://github.com/sage-bionetworks-workflows/nf-cwl-wrap/pkgs/container/nf-cwl-wrap). In addition to switching the base image, I also made some changes to simplify the docker image build including:
- removed multi-stage build
- removed non-essential dependencies installed
- switched `COPY`-ing the contents of the `cwltool` repo to cloning the repository so that the container can be built from within this repo
- Installation of `cwltool` is now done directly into `root`

The second problem to be solved was enabling `DinD` for Nextflow Tower. For local runs of this workflow, this is done by simply mounting volumes in `containerOptions` in the `EXECUTE_CWL_WORKFLOW` process:

```
containerOptions = '-v "/var/run/docker.sock:/var/run/docker.sock" -v /tmp:/tmp'
```

AWS Batch does not pick up on those volumes being mounted, however, and so the following line was added to `nextflow.config` for runs on Tower:

```
aws.batch.volumes = [ '/var/run/docker.sock:/var/run/docker.sock', '/tmp:/tmp' ]
```

With these changes, and with the newly published docker image being used, this workflow has been successfully run (both locally and on Tower) on the example `epic` CWL workflow included as the default params.