### PR TITLE
[IBCDPE-543] Adds file staging

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,21 @@
 
 ## Introduction
 
-`nf-cwl-wrap` is a Nextflow wrapper for CWL workflows. Currently, it only supports executing CWL workflows on a local machine using `cwltool` in a single process workflow. Eventually, it will be fully supported for Nextflow Tower runs. 
+`nf-cwl-wrap` is a Nextflow wrapper for CWL workflows. It uses `cwltool` to execute workflows and can be used both locally and on Nextflow Tower.
 
 ## Workflow Summary
 
-`nf-cwl-wrap` takes a CWL workflow (either local file or raw GitHub user content URL) and an input file (either in YAML or JSON format) as inputs. It then passes these two parameters to a single Nextflow process which executes the CWL workflow using `cwltool`. Any ouputs from the workflow are stored in the `work/` directory. An example input file for the EPIC CWL workflow found [here](https://raw.githubusercontent.com/CRI-iAtlas/iatlas-workflows/develop/EPIC/workflow/steps/epic/epic.cwl) can be found in the `example_inputs/` directory of this repository.
+`nf-cwl-wrap` takes a `.cwl` workflow file (`cwl_file`) and a `.csv` input file (`s3_file`). The `.csv` file is expected to be in the following format:
 
+```
+data_file,input_file
+s3://iatlas-project-tower-bucket/iatlas_fpkm.tsv,s3://iatlas-project-tower-bucket/immune_subtype_clustering_input.json
+```
+
+It should contain paths to a `data_file` - the input data for the CWL workflow, and an `input_file` - a `.json` or `.yaml` file containing the required metadata for the CWL workflow run. The `s3_file` can contain multiple rows in this format. It will create a channel for each row and execute the CWL workflow on the files provided in parallel. Outputs are stored in the working directory for each process execution.
+
+The `s3_file` format is compatible with [`nf-synstage`](https://github.com/Sage-Bionetworks-Workflows/nf-synstage) so that users can first stage their `data_file`'s and `input_file`'s in S3 buckets ahead of Nextflow Tower runs with this repository.
+ 
 ## Quick Start
 
 1. Install [Nextflow](https://www.nextflow.io/docs/latest/getstarted.html#installation) (`>=22.10.1`)

--- a/main.nf
+++ b/main.nf
@@ -1,7 +1,7 @@
 // Ensure DSL2
 nextflow.enable.dsl = 2
 
-params.s3_file = "s3://bwmac-nextflow-test-bucket/s3_file.csv"
+params.s3_file = "s3://iatlas-project-tower-bucket/s3_file.csv"
 //url for example CWL workflow
 params.cwl_file = "https://raw.githubusercontent.com/BWMac/iatlas-workflows/develop/Immune_Subtype_Clustering/workflow/steps/immune_subtype_clustering/immune_subtype_clustering.cwl"
 //example params file

--- a/main.nf
+++ b/main.nf
@@ -9,6 +9,10 @@ params.json_file_name = "immune_subtype_clustering_input.json"
 
 
 process STAGE_INPUTS {
+    debug true
+
+    container "debian:stable-20230411"
+
     input:
     tuple path(input_file), path(data_file)
     path(cwl_file)

--- a/main.nf
+++ b/main.nf
@@ -22,7 +22,6 @@ process STAGE_INPUTS {
 
     script:
     """
-    tail -f /dev/null
     mkdir -p \$PWD/input
     mv ${input_file} \$PWD/input/
     mv ${data_file} \$PWD/input/

--- a/main.nf
+++ b/main.nf
@@ -1,10 +1,29 @@
 // Ensure DSL2
 nextflow.enable.dsl = 2
 
+params.s3_file = "s3://bwmac-nextflow-test-bucket/s3_file.csv"
 //url for example CWL workflow
-params.cwl_file = "https://raw.githubusercontent.com/CRI-iAtlas/iatlas-workflows/develop/EPIC/workflow/steps/epic/epic.cwl"
+params.cwl_file = "https://raw.githubusercontent.com/CRI-iAtlas/iatlas-workflows/develop/Immune_Subtype_Clustering/workflow/steps/immune_subtype_clustering/immune_subtype_clustering.cwl"
 //example params file
-params.input_file = "${projectDir}/example_inputs/epic.json"
+// params.input_file = "${projectDir}/example_inputs/epic.json"
+
+
+process STAGE_INPUTS {
+    debug true
+
+    input:
+    tuple path(input_file), path(data_file)
+
+    output:
+    path input_file
+
+    script:
+    """
+    mkdir -p \$PWD/input
+    mv ${input_file} \$PWD/input/
+    mv ${data_file} \$PWD/input/
+    """
+}
 
 //runs cwl workflow using url and params provided
 process EXECUTE_CWL_WORKFLOW {
@@ -25,7 +44,11 @@ process EXECUTE_CWL_WORKFLOW {
 }
 
 workflow {
-    ch_cwl_file = Channel.fromPath(params.cwl_file)
-    ch_input_file = Channel.fromPath(params.input_file)
-    EXECUTE_CWL_WORKFLOW(ch_cwl_file, ch_input_file)
+    file_ch = Channel.fromPath(params.s3_file)
+                .splitCsv(header:true)
+                .map { row -> tuple(row.input_file, row.data_file) }
+    STAGE_INPUTS(file_ch)
+    // ch_cwl_file = Channel.fromPath(params.cwl_file)
+    // ch_input_file = Channel.fromPath(params.input_file)
+    // EXECUTE_CWL_WORKFLOW(ch_cwl_file, ch_input_file)
 }

--- a/main.nf
+++ b/main.nf
@@ -43,6 +43,9 @@ process EXECUTE_CWL_WORKFLOW {
     path cwl_file
     tuple path(input_file), path(data_file)
 
+    output:
+    path "*.tsv"
+
     script:
     """
     #!/bin/sh

--- a/main.nf
+++ b/main.nf
@@ -17,7 +17,7 @@ process EXECUTE_CWL_WORKFLOW {
     tuple path(input_file), path(data_file)
 
     output:
-    path "*.tsv"
+    path "**"
 
     script:
     """

--- a/main.nf
+++ b/main.nf
@@ -11,7 +11,7 @@ params.json_file_name = "immune_subtype_clustering_input.json"
 process STAGE_INPUTS {
     debug true
 
-    container "debian:stable-20230411"
+    container "ubuntu:22.04"
 
     input:
     tuple path(input_file), path(data_file)
@@ -22,6 +22,7 @@ process STAGE_INPUTS {
 
     script:
     """
+    tail -f /dev/null
     mkdir -p \$PWD/input
     mv ${input_file} \$PWD/input/
     mv ${data_file} \$PWD/input/

--- a/main.nf
+++ b/main.nf
@@ -2,51 +2,51 @@
 nextflow.enable.dsl = 2
 
 params.s3_file = "s3://iatlas-project-tower-bucket/s3_file.csv"
+// params.s3_file = "s3://bwmac-nextflow-test-bucket/s3_file.csv"
 //url for example CWL workflow
 params.cwl_file = "https://raw.githubusercontent.com/BWMac/iatlas-workflows/develop/Immune_Subtype_Clustering/workflow/steps/immune_subtype_clustering/immune_subtype_clustering.cwl"
 //example params file
-params.json_file_name = "immune_subtype_clustering_input.json"
+// params.json_file_name = "immune_subtype_clustering_input.json"
 
 
-process STAGE_INPUTS {
-    debug true
+// process STAGE_INPUTS {
+//     debug true
 
-    container "ubuntu:22.04"
+//     container "ubuntu:22.04"
 
-    input:
-    tuple path(input_file), path(data_file)
-    path(cwl_file)
+//     input:
+//     tuple path(input_file), path(data_file)
+//     path(cwl_file)
 
-    output:
-    stdout
+//     output:
+//     stdout
 
-    script:
-    """
-    mkdir -p \$PWD/input
-    mv ${input_file} \$PWD/input/
-    mv ${data_file} \$PWD/input/
-    mv ${cwl_file} \$PWD/input/
-    echo \$PWD/input/
-    """
-}
+//     script:
+//     """
+//     mkdir -p \$PWD/input
+//     mv ${input_file} \$PWD/input/
+//     mv ${data_file} \$PWD/input/
+//     mv ${cwl_file} \$PWD/input/
+//     echo \$PWD/input/
+//     """
+// }
 
 //runs cwl workflow using url and params provided
 process EXECUTE_CWL_WORKFLOW {
     debug true
     // containerOptions only work when run locally, aws batch volume mounting in nextflow.config for Tower runs
-    containerOptions = '-v /var/run/docker.sock:/var/run/docker.sock -v /tmp:/tmp -v /input:/input'
+    containerOptions = '-v /var/run/docker.sock:/var/run/docker.sock -v /tmp:/tmp -v \$PWD:/input'
     container "ghcr.io/sage-bionetworks-workflows/nf-cwl-wrap:1.0"
 
     input:
-    path input_dir
+    // path input_dir
     path cwl_file
-    val json_file_name
+    tuple path(input_file), path(data_file)
 
     script:
     """
     #!/bin/sh
-    cd input
-    cwltool ${cwl_file} ${json_file_name}
+    cwltool ${cwl_file} ${input_file}
     """
 }
 
@@ -54,8 +54,8 @@ workflow {
     file_ch = Channel.fromPath(params.s3_file)
                 .splitCsv(header:true)
                 .map { row -> tuple(row.input_file, row.data_file) }
-    STAGE_INPUTS(file_ch, params.cwl_file)
+    // STAGE_INPUTS(file_ch, params.cwl_file)
     // ch_cwl_file = Channel.fromPath(params.cwl_file)
     // ch_input_file = Channel.fromPath(params.input_file)
-    EXECUTE_CWL_WORKFLOW(STAGE_INPUTS.output, params.cwl_file, params.json_file_name)
+    EXECUTE_CWL_WORKFLOW(params.cwl_file, file_ch)
 }

--- a/main.nf
+++ b/main.nf
@@ -2,34 +2,8 @@
 nextflow.enable.dsl = 2
 
 params.s3_file = "s3://iatlas-project-tower-bucket/s3_file.csv"
-// params.s3_file = "s3://bwmac-nextflow-test-bucket/s3_file.csv"
 //url for example CWL workflow
 params.cwl_file = "https://raw.githubusercontent.com/CRI-iAtlas/iatlas-workflows/develop/Immune_Subtype_Clustering/workflow/steps/immune_subtype_clustering/immune_subtype_clustering.cwl"
-//example params file
-// params.json_file_name = "immune_subtype_clustering_input.json"
-
-
-// process STAGE_INPUTS {
-//     debug true
-
-//     container "ubuntu:22.04"
-
-//     input:
-//     tuple path(input_file), path(data_file)
-//     path(cwl_file)
-
-//     output:
-//     stdout
-
-//     script:
-//     """
-//     mkdir -p \$PWD/input
-//     mv ${input_file} \$PWD/input/
-//     mv ${data_file} \$PWD/input/
-//     mv ${cwl_file} \$PWD/input/
-//     echo \$PWD/input/
-//     """
-// }
 
 //runs cwl workflow using url and params provided
 process EXECUTE_CWL_WORKFLOW {
@@ -39,7 +13,6 @@ process EXECUTE_CWL_WORKFLOW {
     container "ghcr.io/sage-bionetworks-workflows/nf-cwl-wrap:1.0"
 
     input:
-    // path input_dir
     path cwl_file
     tuple path(input_file), path(data_file)
 
@@ -57,8 +30,5 @@ workflow {
     file_ch = Channel.fromPath(params.s3_file)
                 .splitCsv(header:true)
                 .map { row -> tuple(row.input_file, row.data_file) }
-    // STAGE_INPUTS(file_ch, params.cwl_file)
-    // ch_cwl_file = Channel.fromPath(params.cwl_file)
-    // ch_input_file = Channel.fromPath(params.input_file)
     EXECUTE_CWL_WORKFLOW(params.cwl_file, file_ch)
 }

--- a/main.nf
+++ b/main.nf
@@ -4,7 +4,7 @@ nextflow.enable.dsl = 2
 params.s3_file = "s3://iatlas-project-tower-bucket/s3_file.csv"
 // params.s3_file = "s3://bwmac-nextflow-test-bucket/s3_file.csv"
 //url for example CWL workflow
-params.cwl_file = "https://raw.githubusercontent.com/BWMac/iatlas-workflows/develop/Immune_Subtype_Clustering/workflow/steps/immune_subtype_clustering/immune_subtype_clustering.cwl"
+params.cwl_file = "https://raw.githubusercontent.com/CRI-iAtlas/iatlas-workflows/develop/Immune_Subtype_Clustering/workflow/steps/immune_subtype_clustering/immune_subtype_clustering.cwl"
 //example params file
 // params.json_file_name = "immune_subtype_clustering_input.json"
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -2,4 +2,4 @@ docker {
 	enabled = true
 }
 
-aws.batch.volumes = [ '/var/run/docker.sock:/var/run/docker.sock', '/tmp:/tmp', '${baseDir}:/input' ]
+aws.batch.volumes = [ '/var/run/docker.sock:/var/run/docker.sock', '/tmp:/tmp', "${baseDir}:/input" ]

--- a/nextflow.config
+++ b/nextflow.config
@@ -2,4 +2,4 @@ docker {
 	enabled = true
 }
 
-aws.batch.volumes = [ '/var/run/docker.sock:/var/run/docker.sock', '/tmp:/tmp', '/input:/input' ]
+aws.batch.volumes = [ '/var/run/docker.sock:/var/run/docker.sock', '/tmp:/tmp', '${baseDir}:/input' ]

--- a/nextflow.config
+++ b/nextflow.config
@@ -2,4 +2,4 @@ docker {
 	enabled = true
 }
 
-aws.batch.volumes = [ '/var/run/docker.sock:/var/run/docker.sock', '/tmp:/tmp' ]
+aws.batch.volumes = [ '/var/run/docker.sock:/var/run/docker.sock', '/tmp:/tmp', '/input:/input' ]


### PR DESCRIPTION
This PR implements file staging to this workflow by creating a channel from the rows of an input CSV file and then executing the CWL runs in parallel. It is intended to make this workflow compatible with `nf-synstage`, such that the output CSV file from staging can be immediately fed into this workflow to execute CWL workflows. Initially, I was planning on adding a new process that would stage the needed files into a directory (like `/input`), but I realized that this added the complication of needing to pass that whole directory to the `EXECUTE_CWL_WORKFLOW` process, and that there was really no added benefit to that. Additionally, I realized that I did not need to mount the input files into the Docker containers inside of CWL workflows like I originally thought, just the `ghcr.io/sage-bionetworks-workflows/nf-cwl-wrap` container that we were already using.  To do this I employed a similar strategy to [here](https://github.com/Sage-Bionetworks-Workflows/nf-model2data/pull/1) where I use `PWD` for local runs and `baseDir` to mount the same directory in AWS Batch for Tower runs. 

This workflow has been successfully tested on [this](https://raw.githubusercontent.com/CRI-iAtlas/iatlas-workflows/develop/Immune_Subtype_Clustering/workflow/steps/immune_subtype_clustering/immune_subtype_clustering.cwl) workflow both locally and on Tower. The output files from both runs have been compared and are identical.