### PR TITLE
[IBCDPE-565] Implements CI to publish docker image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [bwmac/IBCDPE-565/implement_ci]
 
 jobs:
   docker-publish:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: CI
+
+on:
+  push:
+    branches: [bwmac/IBCDPE-565/implement_ci]
+
+jobs:
+  docker-publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            ghcr.io/${{ github.repository }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=ref,event=branch
+            type=sha
+            latest
+      - name: Publish Docker Image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          build-args: |
+            TARBALL_PATH=${{ needs.prepare.outputs.tarball-path }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,8 +31,6 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           context: .
-          build-args: |
-            TARBALL_PATH=${{ needs.prepare.outputs.tarball-path }}
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [bwmac/IBCDPE-565/implement_ci]
+    branches: [main]
 
 jobs:
   docker-publish:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    # branches: [bwmac/IBCDPE-565/implement_ci]
+    branches: [bwmac/IBCDPE-565/implement_ci]
 
 jobs:
   docker-publish:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,13 +22,13 @@ jobs:
             ghcr.io/${{ github.repository }}
           tags: |
             type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}.{{minor}} 
             type=semver,pattern={{major}}
             type=ref,event=branch
             type=sha
             latest
       - name: Publish Docker Image
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v4
         with:
           context: .
           build-args: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [bwmac/IBCDPE-565/implement_ci]
+    # branches: [bwmac/IBCDPE-565/implement_ci]
 
 jobs:
   docker-publish:

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,8 @@ WORKDIR /cwltool
 
 # Install cwltool 
 ENV BLACK_VERSION="22.0"
+#upgrade pip
+RUN pip install --upgrade pip
 # The following comes directly from the original docker image (except for ENV version pinning and install location)
 RUN CWLTOOL_USE_MYPYC=1 MYPYPATH=mypy-stubs pip wheel --no-binary schema-salad \
     --wheel-dir=/wheels .[deps]  # --verbose

--- a/main.nf
+++ b/main.nf
@@ -10,7 +10,7 @@ process EXECUTE_CWL_WORKFLOW {
     debug true
     // containerOptions only work when run locally, aws batch volume mounting in nextflow.config for Tower runs
     containerOptions = '-v /var/run/docker.sock:/var/run/docker.sock -v /tmp:/tmp -v \$PWD:/input'
-    container "ghcr.io/sage-bionetworks-workflows/nf-cwl-wrap:1.0"
+    container "ghcr.io/sage-bionetworks-workflows/nf-cwl-wrap:latest"
 
     input:
     path cwl_file


### PR DESCRIPTION
This PR adds a CI workflow to publish a new version of the GHCR image each time there is a push to the main branch. The `ci.yml` file was adapted [from](https://github.com/Sage-Bionetworks-Workflows/nf-model2data/blob/main/.github/workflows/ci.yml) `nf-model2data`. There was also a slight change to `Dockerfile` because pip was not being updated during the build step of the workflow (building was also failing locally). 

I also updated `main.nf` to pin the docker image version to latest so that the newest version is always being used.