### PR TITLE
Enable Wave and Private CWL Containers

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -31,6 +31,7 @@ process EXECUTE_CWL_WORKFLOW {
     #!/bin/sh
     if [ -n "${params.registry_username}" ]; then
         echo \$DOCKERHUB_ACCESS_TOKEN | docker login ${params.registry} -u ${params.registry_username} --password-stdin
+    fi
     cwltool ${cwl_file} ${input_file}
     """
 }

--- a/main.nf
+++ b/main.nf
@@ -18,7 +18,6 @@ process EXECUTE_CWL_WORKFLOW {
     containerOptions = '-v /var/run/docker.sock:/var/run/docker.sock -v /tmp:/tmp -v \$PWD:/input'
     container "ghcr.io/sage-bionetworks-workflows/nf-cwl-wrap:latest"
 
-
     input:
     path cwl_file
     tuple path(input_file), path(data_file)

--- a/main.nf
+++ b/main.nf
@@ -12,7 +12,7 @@ params.registry = "docker.io"
 process EXECUTE_CWL_WORKFLOW {
     debug true
     
-    secret "SYNAPSE_AUTH_TOKEN"
+    secret "DOCKERHUB_ACCESS_TOKEN"
     
     // containerOptions only work when run locally, aws batch volume mounting in nextflow.config for Tower runs
     containerOptions = '-v /var/run/docker.sock:/var/run/docker.sock -v /tmp:/tmp -v \$PWD:/input'
@@ -29,11 +29,10 @@ process EXECUTE_CWL_WORKFLOW {
     script:
     """
     #!/bin/sh
-    echo \$SYNAPSE_AUTH_TOKEN
+    if [ -n "${params.registry_username}" ]; then
+        echo \$DOCKERHUB_ACCESS_TOKEN | docker login ${params.registry} -u ${params.registry_username} --password-stdin
+    cwltool ${cwl_file} ${input_file}
     """
-    // if [ -n "${params.registry_username}" ]; then
-    //     echo \$DOCKERHUB_ACCESS_TOKEN | docker login ${params.registry} -u ${params.registry_username} --password-stdin
-    // cwltool ${cwl_file} ${input_file}
 }
 
 workflow {

--- a/main.nf
+++ b/main.nf
@@ -12,7 +12,7 @@ params.registry = "docker.io"
 process EXECUTE_CWL_WORKFLOW {
     debug true
     
-    secret "DOCKERHUB_ACCESS_TOKEN"
+    secret "SYNAPSE_AUTH_TOKEN"
     
     // containerOptions only work when run locally, aws batch volume mounting in nextflow.config for Tower runs
     containerOptions = '-v /var/run/docker.sock:/var/run/docker.sock -v /tmp:/tmp -v \$PWD:/input'
@@ -29,7 +29,7 @@ process EXECUTE_CWL_WORKFLOW {
     script:
     """
     #!/bin/sh
-    echo \$DOCKERHUB_ACCESS_TOKEN
+    echo \$SYNAPSE_AUTH_TOKEN
     """
     // if [ -n "${params.registry_username}" ]; then
     //     echo \$DOCKERHUB_ACCESS_TOKEN | docker login ${params.registry} -u ${params.registry_username} --password-stdin

--- a/main.nf
+++ b/main.nf
@@ -11,11 +11,13 @@ params.registry = "docker.io"
 //runs cwl workflow using url and params provided
 process EXECUTE_CWL_WORKFLOW {
     debug true
+    
+    secret "DOCKERHUB_ACCESS_TOKEN"
+    
     // containerOptions only work when run locally, aws batch volume mounting in nextflow.config for Tower runs
     containerOptions = '-v /var/run/docker.sock:/var/run/docker.sock -v /tmp:/tmp -v \$PWD:/input'
     container "ghcr.io/sage-bionetworks-workflows/nf-cwl-wrap:latest"
 
-    secret "DOCKERHUB_ACCESS_TOKEN"
 
     input:
     path cwl_file
@@ -27,10 +29,11 @@ process EXECUTE_CWL_WORKFLOW {
     script:
     """
     #!/bin/sh
-    if [ -n "${params.registry_username}" ]; then
-        echo \$DOCKERHUB_ACCESS_TOKEN | docker login ${params.registry} -u ${params.registry_username} --password-stdin
-    cwltool ${cwl_file} ${input_file}
+    echo \$DOCKERHUB_ACCESS_TOKEN
     """
+    // if [ -n "${params.registry_username}" ]; then
+    //     echo \$DOCKERHUB_ACCESS_TOKEN | docker login ${params.registry} -u ${params.registry_username} --password-stdin
+    // cwltool ${cwl_file} ${input_file}
 }
 
 workflow {

--- a/main.nf
+++ b/main.nf
@@ -9,10 +9,8 @@ params.registry_username = ""
 params.registry = "docker.io"
 
 //runs cwl workflow using url and params provided
-process EXECUTE_CWL_WORKFLOW {
-    debug true
-    
-    secret "DOCKERHUB_ACCESS_TOKEN"
+process EXECUTE_CWL_WORKFLOW {    
+    secret "CONTAINER_REGISTRY_ACCESS_TOKEN"
     
     // containerOptions only work when run locally, aws batch volume mounting in nextflow.config for Tower runs
     containerOptions = '-v /var/run/docker.sock:/var/run/docker.sock -v /tmp:/tmp -v \$PWD:/input'
@@ -29,7 +27,7 @@ process EXECUTE_CWL_WORKFLOW {
     """
     #!/bin/sh
     if [ -n "${params.registry_username}" ]; then
-        echo \$DOCKERHUB_ACCESS_TOKEN | docker login ${params.registry} -u ${params.registry_username} --password-stdin
+        echo \$CONTAINER_REGISTRY_ACCESS_TOKEN | docker login ${params.registry} -u ${params.registry_username} --password-stdin
     fi
     cwltool ${cwl_file} ${input_file}
     """

--- a/main.nf
+++ b/main.nf
@@ -5,12 +5,17 @@ params.s3_file = "s3://iatlas-project-tower-bucket/s3_file.csv"
 //url for example CWL workflow
 params.cwl_file = "https://raw.githubusercontent.com/CRI-iAtlas/iatlas-workflows/develop/Immune_Subtype_Clustering/workflow/steps/immune_subtype_clustering/immune_subtype_clustering.cwl"
 
+params.registry_username = ""
+params.registry = "docker.io"
+
 //runs cwl workflow using url and params provided
 process EXECUTE_CWL_WORKFLOW {
     debug true
     // containerOptions only work when run locally, aws batch volume mounting in nextflow.config for Tower runs
     containerOptions = '-v /var/run/docker.sock:/var/run/docker.sock -v /tmp:/tmp -v \$PWD:/input'
     container "ghcr.io/sage-bionetworks-workflows/nf-cwl-wrap:latest"
+
+    secret "DOCKERHUB_ACCESS_TOKEN"
 
     input:
     path cwl_file
@@ -22,6 +27,8 @@ process EXECUTE_CWL_WORKFLOW {
     script:
     """
     #!/bin/sh
+    if [ -n "${params.registry_username}" ]; then
+        echo \$DOCKERHUB_ACCESS_TOKEN | docker login ${params.registry} -u ${params.registry_username} --password-stdin
     cwltool ${cwl_file} ${input_file}
     """
 }

--- a/nextflow.config
+++ b/nextflow.config
@@ -2,4 +2,8 @@ docker {
 	enabled = true
 }
 
+wave {
+	enabled = true
+}
+
 aws.batch.volumes = [ '/var/run/docker.sock:/var/run/docker.sock', '/tmp:/tmp', "${baseDir}:/input" ]


### PR DESCRIPTION
**Description:**

This POC enables CWL workflows that rely on Docker containers from private registries. We may need to apply something like this to `nf-cwl-wrap` to enable us to run the Cibersort [workflow](https://github.com/CRI-iAtlas/iatlas-workflows/blob/develop/Cibersort/workflow/steps/cibersort/cibersort.cwl) for iAtlas.